### PR TITLE
Use `window-total-width' instead of `window-width'.

### DIFF
--- a/popwin.el
+++ b/popwin.el
@@ -271,7 +271,7 @@ which is a node of `window-tree' and OUTLINE which is a node of
 (defun popwin:create-popup-window-1 (window size position)
   "Create a new window with SIZE at POSITION of WINDOW. The
 return value is a list of a master window and the popup window."
-  (let ((width (window-width window))
+  (let ((width (window-total-width window))
         (height (window-height window)))
     (ecase position
       ((left :left)
@@ -304,7 +304,7 @@ window-configuration."
          (vfactor 1))
     (popwin:save-selected-window
      (delete-other-windows root-win))
-    (let ((root-width (window-width root-win))
+    (let ((root-width (window-total-width root-win))
           (root-height (window-height root-win)))
       (when adjust
         (if (floatp size)


### PR DESCRIPTION
The function `window-width` returns the width of the text area, which leads to wrong results with windows that have (wide) margins:

![screenshot from 2015-02-17 13 30 00](https://cloud.githubusercontent.com/assets/191630/6228259/c5043a56-b6a9-11e4-8be4-19bcded5b3fb.png)

The window to the left is originally a frame-wide window with large margins. The window to the right is created with popwin (used in the `guide-key` package). It's obviously far too wide. The problem can be solved by using `window-total-width`, which takes the window margins into account:

![screenshot from 2015-02-17 13 33 46](https://cloud.githubusercontent.com/assets/191630/6228262/d8b6f3f4-b6a9-11e4-9031-69c9c63bcbba.png)
