### PR TITLE
Make popwin aware of window-purpose

### DIFF
--- a/popwin.el
+++ b/popwin.el
@@ -191,7 +191,8 @@ HFACTOR, and vertical factor VFACTOR."
             (window-start node)
             (window-edges node)
             (eq (selected-window) node)
-            (window-dedicated-p node))
+            (window-dedicated-p node)
+	    (window-parameter node 'purpose-dedicated))
     (destructuring-bind (dir edges . windows) node
       (append (list dir edges)
               (loop for window in windows
@@ -212,7 +213,7 @@ horizontal factor HFACTOR, and vertical factor VFACTOR. The
 return value is a association list of mapping from old-window to
 new-window."
   (if (eq (car node) 'window)
-      (destructuring-bind (old-win buffer point start edges selected dedicated)
+      (destructuring-bind (old-win buffer point start edges selected dedicated purpose-dedicated)
           (cdr node)
         (set-window-dedicated-p window nil)
         (popwin:adjust-window-edges window edges hfactor vfactor)
@@ -224,6 +225,8 @@ new-window."
         (set-window-start window start t)
         (when dedicated
           (set-window-dedicated-p window t))
+	(when purpose-dedicated
+	  (set-window-parameter window 'purpose-dedicated t))
         `((,old-win . ,window)))
     (destructuring-bind (dir edges . windows) node
       (loop while windows
@@ -240,7 +243,7 @@ which is a node of `window-tree' and OUTLINE which is a node of
    ((and (windowp node)
          (eq (car outline) 'window))
     ;; same window
-    (destructuring-bind (old-win buffer point start edges selected dedicated)
+    (destructuring-bind (old-win buffer point start edges selected dedicated purpose-dedicated)
         (cdr outline)
       (popwin:adjust-window-edges node edges)
       (when (and (eq (window-buffer node) buffer)


### PR DESCRIPTION
Hi, I wrote a package ([Purpose](https://github.com/bmag/emacs-purpose)) that provides an alternative window manager for Emacs, and I ran into a some problems when using it together with popwin.

In short, my package sets a window parameter named 'purpose-dedicated, and popwin doesn't restore this parameter in popwin:replicate-window-config.

This PR fixes the issue. I ran `make test` and all tests passed, so it shouldn't disrupt anything.
I didn't want to make any changes to popwin, but I don't think there is a better way to make both packages work well together.

Please merge this PR, it would be helpful to anyone who wants to use both Purpose and popwin :-)

P.S. this also lets me fix an issue with guide-key (which uses popwin) and spacemacs (which uses guide-key)