### PR TITLE
Make popwin don't treat the only window as popup.

### DIFF
--- a/popwin.el
+++ b/popwin.el
@@ -557,7 +557,8 @@ the popup window will be closed are followings:
                 (not popup-window-alive)
                 (and other-window-selected
                      (not minibuf-window-p)
-                     (not popwin:popup-window-stuck-p)))
+                     (not popwin:popup-window-stuck-p))
+                (= (length (window-list)) 1))
         (when popwin:debug
           (message (concat "popwin: CLOSE:\n"
                            "  quit-requested = %s\n"


### PR DESCRIPTION
When the user invoked `delete-other-windows` command to enlarge the popup window, for example, we should no longer treat the only window as a popup I think.